### PR TITLE
Build merkle tree concurrently

### DIFF
--- a/client/download.go
+++ b/client/download.go
@@ -151,11 +151,8 @@ func CallDownloadFiles(bankhome, serverName, bankName string, fileNumber int) er
 	merkleProof := merkle.MerkleProof{
 		Hashes: serverProof,
 	}
-	validProof, err := merkleProof.VerifyFileProof(fileAndProof.File, [32]byte(bank.MerkleRoot))
-	if err != nil {
-		return err
-	}
-	if !validProof {
+
+	if validProof := merkleProof.VerifyFileProof(fileAndProof.File, [32]byte(bank.MerkleRoot)); !validProof {
 		return errors.New("Invalid merkle proof")
 	}
 

--- a/merkle/proof.go
+++ b/merkle/proof.go
@@ -12,9 +12,9 @@ type MerkleProof struct {
 	Hashes [][32]byte
 }
 
-func (p MerkleProof) VerifyFileProof(file []byte, merkleRoot [32]byte) (bool, error) {
+func (p MerkleProof) VerifyFileProof(file []byte, merkleRoot [32]byte) bool {
 	leaf := cr.HashTwice(file)
-	return p.verifyLeafProof(leaf, merkleRoot), nil
+	return p.verifyLeafProof(leaf, merkleRoot)
 }
 
 func (p MerkleProof) GetProofInHex() []string {

--- a/merkle/proof.go
+++ b/merkle/proof.go
@@ -12,6 +12,19 @@ type MerkleProof struct {
 	Hashes [][32]byte
 }
 
+func (p MerkleProof) VerifyFileProof(file []byte, merkleRoot [32]byte) (bool, error) {
+	leaf := cr.HashTwice(file)
+	return p.verifyLeafProof(leaf, merkleRoot), nil
+}
+
+func (p MerkleProof) GetProofInHex() []string {
+	var hexProof []string
+	for _, hash := range p.Hashes {
+		hexProof = append(hexProof, hex.EncodeToString(hash[:]))
+	}
+	return hexProof
+}
+
 func (m MerkleTree) generateProof(leaf [32]byte) (*MerkleProof, error) {
 	if len(m.Hashes) == 0 {
 		return nil, errors.New("cannot generate proof from empty tree")
@@ -41,19 +54,6 @@ func (m MerkleTree) generateProof(leaf [32]byte) (*MerkleProof, error) {
 		Leaf:   leaf,
 		Hashes: proof,
 	}, nil
-}
-
-func (p MerkleProof) GetProofInHex() []string {
-	var hexProof []string
-	for _, hash := range p.Hashes {
-		hexProof = append(hexProof, hex.EncodeToString(hash[:]))
-	}
-	return hexProof
-}
-
-func (p MerkleProof) VerifyFileProof(file []byte, merkleRoot [32]byte) (bool, error) {
-	leaf := cr.HashTwice(file)
-	return p.verifyLeafProof(leaf, merkleRoot), nil
 }
 
 func (p MerkleProof) verifyLeafProof(leaf [32]byte, merkleRoot [32]byte) bool {

--- a/merkle/proof.go
+++ b/merkle/proof.go
@@ -14,12 +14,10 @@ type MerkleProof struct {
 
 func (m MerkleTree) generateProof(leaf [32]byte) (*MerkleProof, error) {
 	if len(m.Hashes) == 0 {
-		return nil, errors.New("Cannot generate proof from empty tree")
+		return nil, errors.New("cannot generate proof from empty tree")
 	}
-
 	// get leaf position in tree
 	leafIndex, err := m.getNodeIndex(leaf)
-
 	if err != nil {
 		return nil, err
 	}
@@ -30,18 +28,15 @@ func (m MerkleTree) generateProof(leaf [32]byte) (*MerkleProof, error) {
 		}, nil
 	}
 	if leafIndex == -1 {
-		return nil, errors.New("Leaf is not part of the tree")
+		return nil, errors.New("leaf is not part of the tree")
 	}
-
 	// TODO: check that found index is a leaf
-
 	var proof [][32]byte
 	currentIndex := leafIndex
 	for currentIndex != 0 {
 		proof = append(proof, m.Hashes[getNodeSiblingIndex(currentIndex)])
 		currentIndex = getNodeParentIndex(currentIndex)
 	}
-
 	return &MerkleProof{
 		Leaf:   leaf,
 		Hashes: proof,
@@ -50,11 +45,9 @@ func (m MerkleTree) generateProof(leaf [32]byte) (*MerkleProof, error) {
 
 func (p MerkleProof) GetProofInHex() []string {
 	var hexProof []string
-
 	for _, hash := range p.Hashes {
 		hexProof = append(hexProof, hex.EncodeToString(hash[:]))
 	}
-
 	return hexProof
 }
 

--- a/merkle/proof_test.go
+++ b/merkle/proof_test.go
@@ -6,67 +6,53 @@ import (
 )
 
 func TestNominalProof(t *testing.T) {
-	var tree MerkleTree
-
 	// testData
 	var files [][]byte
 	for i := 0; i < 100; i++ {
 		files = append(files, []byte(fmt.Sprintf("TEST%d", i)))
 	}
 
-	err := tree.BuildMerkleTree(files)
-
-	if err != nil {
-		t.Errorf("Error occured when generating tree: %v", err)
-		return
+	var tree MerkleTree
+	if err := tree.BuildMerkleTree(files); err != nil {
+		t.Errorf("error occured when generating tree: %v", err)
+		t.FailNow()
 	}
-
 	for i, file := range files {
 		proof, err := tree.GenerateProofForFile(file)
 		if err != nil {
-			t.Errorf("Error occured when generating proof: %v", err)
-			return
+			t.Errorf("error occured when generating proof: %v", err)
+			t.FailNow()
 		}
 		isValidProof, err := proof.VerifyFileProof(file, tree.GetMerkleRoot())
 		if err != nil {
-			t.Errorf("Error occured when verifying proof: %v", err)
-			return
-		}
-		if !isValidProof {
-			t.Errorf("Failed to verify proof for file %v", i)
-			return
+			t.Errorf("error occured when verifying proof: %v", err)
+		} else if !isValidProof {
+			t.Errorf("failed to verify proof for file %v", i)
 		}
 	}
 }
 
 func TestFailVerification(t *testing.T) {
-	var tree MerkleTree
-
 	// testData
 	var files [][]byte
 	for i := 0; i < 100; i++ {
 		files = append(files, []byte(fmt.Sprintf("TEST%d", i)))
 	}
 
-	err := tree.BuildMerkleTree(files)
-
-	if err != nil {
-		t.Errorf("Error occured when generating tree: %v", err)
+	var tree MerkleTree
+	if err := tree.BuildMerkleTree(files); err != nil {
+		t.Errorf("error when generating tree: %v", err)
 		return
 	}
-
 	proof, err := tree.GenerateProofForFile(files[0])
 	if err != nil {
-		t.Errorf("Error occured when generating proof: %v", err)
-		return
+		t.Errorf("error when generating proof: %v", err)
+		t.FailNow()
 	}
 	isValidProof, err := proof.VerifyFileProof(files[5], tree.GetMerkleRoot())
 	if err != nil {
-		t.Errorf("Error occured when verifying proof: %v", err)
-		return
-	}
-	if isValidProof {
-		t.Errorf("Expected proof verification to fail, got success")
-		return
+		t.Errorf("error when verifying proof: %v", err)
+	} else if isValidProof {
+		t.Errorf("expected proof verification to fail, got success")
 	}
 }

--- a/merkle/proof_test.go
+++ b/merkle/proof_test.go
@@ -32,6 +32,13 @@ func TestNominalProof(t *testing.T) {
 	}
 }
 
+func TestNoProofFromEmptyTree(t *testing.T) {
+	var tree MerkleTree
+	if _, err := tree.generateProof([32]byte{}); err == nil {
+		t.Errorf("generateProof should return error when tree is empty")
+	}
+}
+
 func TestFailVerification(t *testing.T) {
 	// testData
 	var files [][]byte

--- a/merkle/proof_test.go
+++ b/merkle/proof_test.go
@@ -47,7 +47,7 @@ func TestFailVerification(t *testing.T) {
 	var tree MerkleTree
 	if err := tree.BuildMerkleTree(files); err != nil {
 		t.Errorf("error when generating tree: %v", err)
-		return
+		t.FailNow()
 	}
 	proof, err := tree.GenerateProofForFile(files[0])
 	if err != nil {

--- a/merkle/proof_test.go
+++ b/merkle/proof_test.go
@@ -23,10 +23,8 @@ func TestNominalProof(t *testing.T) {
 			t.Errorf("error occured when generating proof: %v", err)
 			t.FailNow()
 		}
-		isValidProof, err := proof.VerifyFileProof(file, tree.GetMerkleRoot())
-		if err != nil {
-			t.Errorf("error occured when verifying proof: %v", err)
-		} else if !isValidProof {
+
+		if isValidProof := proof.VerifyFileProof(file, tree.GetMerkleRoot()); !isValidProof {
 			t.Errorf("failed to verify proof for file %v", i)
 		}
 	}
@@ -56,10 +54,8 @@ func TestFailVerification(t *testing.T) {
 		t.Errorf("error when generating proof: %v", err)
 		t.FailNow()
 	}
-	isValidProof, err := proof.VerifyFileProof(files[5], tree.GetMerkleRoot())
-	if err != nil {
-		t.Errorf("error when verifying proof: %v", err)
-	} else if isValidProof {
+
+	if isValidProof := proof.VerifyFileProof(files[5], tree.GetMerkleRoot()); isValidProof {
 		t.Errorf("expected proof verification to fail, got success")
 	}
 }

--- a/merkle/tree.go
+++ b/merkle/tree.go
@@ -21,35 +21,29 @@ func (m MerkleTree) GetMerkleRoot() [32]byte {
 
 func (m MerkleTree) GetTreeInHex() []string {
 	var hexTree []string
-
 	for _, hash := range m.Hashes {
 		hexTree = append(hexTree, hex.EncodeToString(hash[:]))
 	}
-
 	return hexTree
 }
 
 func (m *MerkleTree) BuildMerkleTree(files [][]byte) error {
 	if len(files) == 0 {
-		return errors.New("Cannot create tree from empty slice")
+		return errors.New("cannot create tree from empty slice")
 	}
 	var leafs [][32]byte
-
 	for _, file := range files {
 		leafs = append(leafs, cr.HashTwice(file))
 	}
-
 	tree := merkleTreeFromLeafs(leafs)
-
 	m.Hashes = tree
-
 	return nil
 }
 
 func (m MerkleTree) getNodeIndex(leaf [32]byte) (int, error) {
 	size := len(m.Hashes)
 	if size == 0 {
-		return -1, errors.New("Cannot search in empty tree")
+		return -1, errors.New("cannot search in empty tree")
 	}
 	nbLeafs := (size + 1) / 2
 	low := size - nbLeafs
@@ -73,12 +67,10 @@ func (m MerkleTree) getNodeIndex(leaf [32]byte) (int, error) {
 
 func (m MerkleTree) GenerateProofForFile(file []byte) (*MerkleProof, error) {
 	leaf := cr.HashTwice(file)
-
 	proof, err := m.generateProof(leaf)
 	if err != nil {
 		return nil, err
 	}
-
 	return proof, nil
 }
 
@@ -87,20 +79,16 @@ func merkleTreeFromLeafs(leafs [][32]byte) [][32]byte {
 	sort.Slice(leafs, func(i, j int) bool {
 		return cr.CompareHashes(leafs[i], leafs[j])
 	})
-
 	treeLen := len(leafs)*2 - 1
 	tree := make([][32]byte, treeLen)
-
 	// insert leafs at end of buffer in reverse order
 	for i, leaf := range leafs {
 		tree[treeLen-1-i] = leaf
 	}
-
 	// compute nodes
 	for i := treeLen - len(leafs) - 1; i >= 0; i-- {
 		tree[i] = concatAndHash(tree[2*i+1], tree[2*i+2])
 	}
-
 	return tree
 }
 

--- a/merkle/tree.go
+++ b/merkle/tree.go
@@ -12,21 +12,6 @@ type MerkleTree struct {
 	Hashes [][32]byte
 }
 
-func (m MerkleTree) GetMerkleRoot() [32]byte {
-	if len(m.Hashes) > 0 {
-		return m.Hashes[0]
-	}
-	return [32]byte{}
-}
-
-func (m MerkleTree) GetTreeInHex() []string {
-	var hexTree []string
-	for _, hash := range m.Hashes {
-		hexTree = append(hexTree, hex.EncodeToString(hash[:]))
-	}
-	return hexTree
-}
-
 func (m *MerkleTree) BuildMerkleTree(files [][]byte) error {
 	if len(files) == 0 {
 		return errors.New("cannot create tree from empty slice")
@@ -38,6 +23,30 @@ func (m *MerkleTree) BuildMerkleTree(files [][]byte) error {
 	tree := merkleTreeFromLeafs(leafs)
 	m.Hashes = tree
 	return nil
+}
+
+func (m MerkleTree) GetMerkleRoot() [32]byte {
+	if len(m.Hashes) > 0 {
+		return m.Hashes[0]
+	}
+	return [32]byte{}
+}
+
+func (m MerkleTree) GenerateProofForFile(file []byte) (*MerkleProof, error) {
+	leaf := cr.HashTwice(file)
+	proof, err := m.generateProof(leaf)
+	if err != nil {
+		return nil, err
+	}
+	return proof, nil
+}
+
+func (m MerkleTree) GetTreeInHex() []string {
+	var hexTree []string
+	for _, hash := range m.Hashes {
+		hexTree = append(hexTree, hex.EncodeToString(hash[:]))
+	}
+	return hexTree
 }
 
 func (m MerkleTree) getNodeIndex(leaf [32]byte) (int, error) {
@@ -63,15 +72,6 @@ func (m MerkleTree) getNodeIndex(leaf [32]byte) (int, error) {
 		return -1, nil
 	}
 	return low, nil
-}
-
-func (m MerkleTree) GenerateProofForFile(file []byte) (*MerkleProof, error) {
-	leaf := cr.HashTwice(file)
-	proof, err := m.generateProof(leaf)
-	if err != nil {
-		return nil, err
-	}
-	return proof, nil
 }
 
 func merkleTreeFromLeafs(leafs [][32]byte) [][32]byte {

--- a/merkle/tree_test.go
+++ b/merkle/tree_test.go
@@ -16,7 +16,7 @@ func TestNoEmptyTree(t *testing.T) {
 	}
 }
 
-func TestNominalTree(t *testing.T) {
+func TestKnownTree(t *testing.T) {
 	// testData
 	a := []byte("TEST1")
 	b := []byte("TEST2")
@@ -40,5 +40,30 @@ func TestNominalTree(t *testing.T) {
 			fmt.Println(hash)
 		}
 		t.Errorf("merkle roots do not match. Expected %v, got %v", expectedRoot, gotRoot)
+	}
+}
+
+func TestTreeStructure(t *testing.T) {
+	for i := 1; i <= 10; i++ {
+		var files [][]byte
+		for j := 0; j < i; j++ {
+			files = append(files, []byte(fmt.Sprintf("TEST%d", j)))
+		}
+		var tree MerkleTree
+		if err := tree.BuildMerkleTree(files); err != nil {
+			t.Errorf("error when generating tree: %v", err)
+			t.FailNow()
+		}
+		for index, node := range tree.Hashes {
+			if node == [32]byte{} {
+				// print tree for debug
+				hexTree := tree.GetTreeInHex()
+				for _, hash := range hexTree {
+					fmt.Println(hash)
+				}
+				t.Errorf("error in tree structure: files=%v, index=%v", i, index)
+				t.FailNow()
+			}
+		}
 	}
 }

--- a/merkle/tree_test.go
+++ b/merkle/tree_test.go
@@ -31,8 +31,9 @@ func TestNominalTree(t *testing.T) {
 		t.Errorf("error occured when building tree: %v", err)
 		t.FailNow()
 	}
-	gotRoot := tree.GetMerkleRoot()
-	if expectedRoot != hex.EncodeToString(gotRoot[:]) {
+	root := tree.GetMerkleRoot()
+	gotRoot := hex.EncodeToString(root[:])
+	if expectedRoot != gotRoot {
 		// print full tree for debugging
 		hexTree := tree.GetTreeInHex()
 		for _, hash := range hexTree {

--- a/merkle/tree_test.go
+++ b/merkle/tree_test.go
@@ -7,20 +7,16 @@ import (
 )
 
 func TestNoEmptyTree(t *testing.T) {
-	var tree MerkleTree
-
 	// testData
 	var files [][]byte
-	err := tree.BuildMerkleTree(files)
 
-	if err == nil {
-		t.Errorf("Expected error, got no error")
+	var tree MerkleTree
+	if err := tree.BuildMerkleTree(files); err == nil {
+		t.Errorf("merkle tree builder should return error when tree is empty")
 	}
 }
 
 func TestNominalTree(t *testing.T) {
-	var tree MerkleTree
-
 	// testData
 	a := []byte("TEST1")
 	b := []byte("TEST2")
@@ -30,21 +26,18 @@ func TestNominalTree(t *testing.T) {
 	files := [][]byte{e, b, c, d, a}
 	expectedRoot := "49e5171f64c94c819582d1b433156a604b916ef5774765be78c6dc646585a7fa"
 
-	err := tree.BuildMerkleTree(files)
-
-	if err != nil {
-		t.Errorf("Error occured when creating tree: %v", err)
-	} else {
-		gotRoot := tree.GetMerkleRoot()
-
+	var tree MerkleTree
+	if err := tree.BuildMerkleTree(files); err != nil {
+		t.Errorf("error occured when building tree: %v", err)
+		t.FailNow()
+	}
+	gotRoot := tree.GetMerkleRoot()
+	if expectedRoot != hex.EncodeToString(gotRoot[:]) {
 		// print full tree for debugging
 		hexTree := tree.GetTreeInHex()
 		for _, hash := range hexTree {
 			fmt.Println(hash)
 		}
-
-		if expectedRoot != hex.EncodeToString(gotRoot[:]) {
-			t.Errorf("Merkle roots do not match. Expected %v, got %v", expectedRoot, gotRoot)
-		}
+		t.Errorf("merkle roots do not match. Expected %v, got %v", expectedRoot, gotRoot)
 	}
 }


### PR DESCRIPTION
Merkle tree can be built concurrently by spawning `nbLeafs/2` or  `nbLeafs/2 - 1` goroutines.

Each goroutine computes the parent node of two sibling leafs, then the parent of that new node if its sibling has already been computed, and so on until finding an empty sibling. Goroutines finding empty siblings will return, and the algorithm's end is when the final remaining goroutine calculates the root and signals the calling function via a channel.

This implementation uses a slice of atomic buffers to handle concurrent read/write. At worst, two goroutines will attempt a read and write on the same buffer **once**, contention in this case is sufficiently low, and atomics are more efficient than one mutex per buffer.

Note: agressively spawning `nbLeafs/2` goroutines is not ideal, a worker pool model would be more efficient.